### PR TITLE
🎨 Add: ChatEvent Entity to record kick,ban,mute event

### DIFF
--- a/src/entities/chat-event.entity.ts
+++ b/src/entities/chat-event.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Column, CreateDateColumn, DeleteDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn,
+} from 'typeorm';
+import ChatParticipant from './chat-participant.entity';
+import Chat from './chat.entity';
+
+const enum ChatEventType {
+  BAN = 'BAN',
+  KICK = 'KICK',
+  MUTE = 'MUTE',
+}
+
+@Entity()
+export class ChatEvent {
+  @PrimaryGeneratedColumn()
+    eventSeq: number;
+
+  @Column()
+    eventType: ChatEventType;
+
+  @ManyToOne(() => ChatParticipant)
+  @JoinColumn({ name: 'fromWho' })
+    fromWho: ChatParticipant;
+
+  @ManyToOne(() => ChatParticipant)
+  @JoinColumn({ name: 'toWho' })
+    toWho: ChatParticipant;
+
+  @ManyToOne(() => Chat)
+    chatSeq: Chat;
+
+  @CreateDateColumn({ default: new Date() })
+    createdAt: Date;
+
+  @DeleteDateColumn({ default: new Date() })
+    deletedAt: Date;
+}

--- a/src/entities/chat-participant.entity.ts
+++ b/src/entities/chat-participant.entity.ts
@@ -1,7 +1,10 @@
 import PartcAuth from 'src/enums/mastercode/partc-auth.enum';
 import {
-  Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn,
 } from 'typeorm';
+import { ChatEvent } from './chat-event.entity';
 import Chat from './chat.entity';
 import User from './user.entity';
 
@@ -28,7 +31,7 @@ export default class ChatParticipant {
   @CreateDateColumn()
     enteredAt: Date;
 
-  @CreateDateColumn()
+  @DeleteDateColumn()
     leavedAt: Date;
 
   @ManyToOne(() => Chat, (chat) => chat.chatSeq)
@@ -38,4 +41,10 @@ export default class ChatParticipant {
   @ManyToOne(() => User, (user) => user.userSeq)
   @JoinColumn({ name: 'userSeq' })
     user: User;
+
+  @OneToMany(() => ChatEvent, (chatEvent) => chatEvent.fromWho)
+    fromWho: ChatEvent[];
+
+  @OneToMany(() => ChatEvent, (chatEvent) => chatEvent.toWho)
+    toWho: ChatEvent[];
 }

--- a/src/entities/chat.entity.ts
+++ b/src/entities/chat.entity.ts
@@ -2,6 +2,7 @@ import ChatType from 'src/enums/mastercode/chat-type.enum';
 import {
   Column, Entity, OneToMany, PrimaryGeneratedColumn,
 } from 'typeorm';
+import { ChatEvent } from './chat-event.entity';
 import ChatParticipant from './chat-participant.entity';
 import Message from './message.entity';
 
@@ -27,4 +28,7 @@ export default class Chat {
 
   @OneToMany(() => ChatParticipant, (chatParticipant) => chatParticipant.chatSeq)
     partcSeq: ChatParticipant[];
+
+  @OneToMany(() => ChatEvent, (chatEvent) => chatEvent.chatSeq)
+    eventSeq: ChatEvent[];
 }


### PR DESCRIPTION
## 수정 및 작업 내용
- 채팅방 이벤트 기록을 위한 테이블을 만들었습니다.

## 사유
- 기존의 채팅참여자 테이블을 계속해서 수정하면서 내역을 확인하기 보다 계속해서 로그를 만들어서 추방, 킥, 뮤트에 대한 이력을 남기고
채팅방 내부에서 일어날 수 있는 이벤트의 다양성을 확장시키기에 유리한 구조를 선택했습니다.
