### PR TITLE
Refac: socket.io event naming and data #38

### DIFF
--- a/src/game-log/game-queue.ts
+++ b/src/game-log/game-queue.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import GameType from 'src/enums/mastercode/game-type.enum';
 import { GameSession } from './interface/game-session';
 
 @Injectable()
@@ -12,14 +13,15 @@ export class GameQueue {
   enQueue(client: GameSession, isLadder: string): Promise<GameSession[] | boolean> {
     this.logger.debug(client);
     // TODO: check duplicates
-    if (isLadder) {
+    if (isLadder === GameType.LADDER) {
       return this.addToLadder(client);
     }
     return this.addToNormal(client);
   }
 
-  deQueue(client:GameSession, isLadder:boolean): void {
-    if (isLadder) {
+  deQueue(client:GameSession, isLadder: string): void {
+    this.logger.debug(client);
+    if (isLadder === GameType.LADDER) {
       return this.removeFromLadder(client);
     }
     return this.removeFromNormal(client);

--- a/src/game-log/game.service.ts
+++ b/src/game-log/game.service.ts
@@ -26,7 +26,7 @@ export class GameService {
     private simulator: SimulationService,
   ) {}
 
-  async handleEnqueue(client: GameSession, isLadder: GameType) {
+  async handleEnqueue(client: GameSession, isLadder: GameType) : Promise<GameSession[] | void> {
     const ret = await this.gameQueue.enQueue(client, isLadder);
     if (typeof ret === 'object') {
       const newGame = new GameData();
@@ -37,6 +37,7 @@ export class GameService {
         isLadder,
       );
       newGame.ruleData = new RuleData();
+      newGame.inGameData = new InGameData();
       this.games.set(newGame.metaData.roomId, newGame);
       this.readyCheck.set(newGame.metaData.roomId, false);
       ret[0].roomId = newGame.metaData.roomId;
@@ -45,7 +46,7 @@ export class GameService {
     }
   }
 
-  handleDequeue(client: GameSession, isLadder: boolean) {
+  handleDequeue(client: GameSession, isLadder: GameType) {
     return this.gameQueue.deQueue(client, isLadder);
   }
 
@@ -71,7 +72,7 @@ export class GameService {
     const ready = this.readyCheck.get(roomId);
     if (ready && isReady) {
       const game = this.games.get(roomId);
-      this.eventRunner.emit('game:start', game);
+      this.eventRunner.emit('game:ready', game);
     } else {
       this.readyCheck.set(roomId, isReady);
     }

--- a/src/game-log/simulation.service.ts
+++ b/src/game-log/simulation.service.ts
@@ -66,7 +66,10 @@ export class SimulationService {
           break;
         }
         case GameStatus.End: {
-          this.eventRunner.emit('game:end', roomId, metaData, inGameData);
+          this.eventRunner.emit('game:end', roomId, {
+            metaData,
+            inGameData,
+          });
           break;
         }
         default: {
@@ -167,9 +170,13 @@ export class SimulationService {
 
   private countReadyAndStart(roomId: string, inGameData: InGameData): boolean {
     if (inGameData.frame === 1) {
-      this.eventRunner.emit('game:ready', roomId, 'ready');
+      this.eventRunner.emit('game:start', roomId, {
+        status: 'ready',
+      });
     } else if (inGameData.frame === 1200) {
-      this.eventRunner.emit('game:ready', roomId, 'start');
+      this.eventRunner.emit('game:start', roomId, {
+        status: 'start',
+      });
     } else if (inGameData.frame > 1200) {
       return true;
     }


### PR DESCRIPTION
## 수정 및 작업 내용
- 소켓 명세를 작성하면서 정리되는 이벤트 네임이나 데이터 형식에 리팩토링이 있었습니다.

## 사유
- 좀 더 이벤트명을 통해 해당 통신이 어떤역할을 할 수 있는지 직관적으로 이해할 수 있도록 했습니다.
- 예전에 말씀하신 데이터 포맷을 일치시키는 의견은 적용되지 않았습니다. 추후 수정 예정입니다.
