### PR TITLE
사용자 정보 CRUD 및 OAuth 관련 일부 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,14 +8,12 @@ import { FtGuard } from './guards/ft.guard';
 export class AuthController {
   @Get('42')
   @UseGuards(FtGuard)
-  login() {
-  }
+  login() { }
 
   @Get('42/callback')
   @UseGuards(FtGuard)
   @Redirect('../../../', 302)
-  callback(@Req() req: any) {
-  }
+  callback() { }
 
   @Get('logout')
   @UseGuards(AuthGuard)

--- a/src/auth/ft.strategy.ts
+++ b/src/auth/ft.strategy.ts
@@ -13,27 +13,25 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
     super({
       clientID: configService.get('auth.clientid'),
       clientSecret: configService.get('auth.clientsecret'),
-      callbackURL: '/auth/42/callback',
+      callbackURL: '/api/auth/42/callback',
       passReqToCallback: true,
       profileFields: {
         userId: 'id',
         email: 'email',
+        login: 'login',
       },
     });
   }
 
   async validate(req, at, rt, profile, cb) {
-    try {
-      const result = await this.userService.findByOAuthId(profile.userId)
-      ?? await this.userService.createByUserId(profile.userId, profile.email);
-      if (result === undefined) {
-        throw new Error('User not found');
-      }
-      cb(null, {
-        seq: result,
-      });
-    } catch (err) {
-      cb(err);
-    }
+    await this.userService.createByUserId(
+      profile.userId,
+      profile.email,
+      profile.login,
+    );
+    const result = await this.userService.findByOAuthId(profile.userId);
+    cb(null, {
+      seq: result,
+    });
   }
 }

--- a/src/user/dto/get-user.dto.ts
+++ b/src/user/dto/get-user.dto.ts
@@ -12,7 +12,7 @@ export class GetUserDto {
     userName: string;
 
   @ApiProperty({
-    description: '유저 닉네임',
+    description: '유저 이메일',
     example: 'skim@student.42seoul.kr',
   })
   @IsString()
@@ -20,7 +20,7 @@ export class GetUserDto {
     userEmail: string;
 
   @ApiProperty({
-    description: '유저 닉네임',
+    description: '유저 상태',
     enum: ['USST10', 'USST20', 'USST30', 'USST40'],
     example: 'skim',
   })
@@ -28,7 +28,7 @@ export class GetUserDto {
     userStatus: UserStatus;
 
   @ApiProperty({
-    description: '유저 닉네임',
+    description: '유저 프로필 사진',
     example: './img/defaultProfile.jpg',
   })
   @IsString()

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -12,26 +12,26 @@ export class UpdateUserDto {
   @IsNotEmpty()
     nickName: string;
 
-    @ApiProperty({
-      description: '유저 이메일',
-      example: 'skim@student.42seoul.kr',
-    })
+  @ApiProperty({
+    description: '유저 이메일',
+    example: 'skim@student.42seoul.kr',
+  })
   @IsEmail()
   @IsNotEmpty()
     email: string;
 
-    @ApiProperty({
-      description: '2차 인증 여부',
-      example: false,
-    })
+  @ApiProperty({
+    description: '2차 인증 여부',
+    example: false,
+  })
   @IsBoolean()
   @IsNotEmpty()
     secAuthStatus: boolean;
 
-    @ApiProperty({
-      description: '유저 프로필 사진',
-      example: './img/defaultProfile.jpg',
-    })
+  @ApiProperty({
+    description: '유저 프로필 사진',
+    example: './img/defaultProfile.jpg',
+  })
   @IsString()
   @IsNotEmpty()
     avatarImgUri: string;

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,21 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsBoolean, IsEmail, IsNotEmpty, IsString, IsUrl,
+  IsBoolean, IsEmail, IsNotEmpty, IsString,
 } from 'class-validator';
 
 export class UpdateUserDto {
+  @ApiProperty({
+    description: '유저 닉네임',
+    example: 'skim',
+  })
   @IsString()
   @IsNotEmpty()
     nickName: string;
 
+    @ApiProperty({
+      description: '유저 이메일',
+      example: 'skim@student.42seoul.kr',
+    })
   @IsEmail()
   @IsNotEmpty()
     email: string;
 
+    @ApiProperty({
+      description: '2차 인증 여부',
+      example: false,
+    })
   @IsBoolean()
   @IsNotEmpty()
     secAuthStatus: boolean;
 
-  @IsUrl()
+    @ApiProperty({
+      description: '유저 프로필 사진',
+      example: './img/defaultProfile.jpg',
+    })
+  @IsString()
   @IsNotEmpty()
     avatarImgUri: string;
 }

--- a/src/user/repository/mock/mock.user-profile.repository.ts
+++ b/src/user/repository/mock/mock.user-profile.repository.ts
@@ -52,7 +52,7 @@ export default class MockUserProfileRepository {
     return true;
   }
 
-  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<GetUserDto> {
+  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<UpdateUserDto> {
     const userIdx = await this.MockEntity.findIndex((u) => u.userSeq === userSeq);
     this.MockEntity[userIdx].nickName = userData.nickName;
     this.MockEntity[userIdx].email = userData.email;
@@ -60,10 +60,10 @@ export default class MockUserProfileRepository {
     this.MockEntity[userIdx].avatarImgUri = userData.avatarImgUri;
 
     return ({
-      userName: this.MockEntity[userIdx].nickName,
-      userEmail: this.MockEntity[userIdx].email,
-      userStatus: this.MockEntity[userIdx].status,
-      userImage: this.MockEntity[userIdx].avatarImgUri,
+      nickName: this.MockEntity[userIdx].nickName,
+      email: this.MockEntity[userIdx].email,
+      secAuthStatus: this.MockEntity[userIdx].secAuthStatus,
+      avatarImgUri: this.MockEntity[userIdx].avatarImgUri,
     });
   }
 

--- a/src/user/repository/mock/mock.user.repository.ts
+++ b/src/user/repository/mock/mock.user.repository.ts
@@ -40,11 +40,11 @@ export default class MockUserRepository {
     this.MockEntity.push(userData);
   }
 
-  async createUser(oauthId: number, email: string) {
+  async createUser(oauthId: number, email: string, name: string) {
     const user = {
       userSeq: this.MockEntity.length + 1,
       userId: oauthId,
-      nickName: email,
+      nickName: name,
       email,
       sedAuthStatus: false,
       avatarImgUri: './img/defaultProfile.jpg',

--- a/src/user/repository/user-profile.repository.ts
+++ b/src/user/repository/user-profile.repository.ts
@@ -26,7 +26,7 @@ export class UserProfileRepository extends Repository<User> {
     return true;
   }
 
-  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<GetUserDto> {
+  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<UpdateUserDto> {
     const user = await this.findOne(userSeq);
     user.nickName = userData.nickName;
     user.email = userData.email;
@@ -34,10 +34,10 @@ export class UserProfileRepository extends Repository<User> {
     user.avatarImgUri = userData.avatarImgUri;
     await this.save(user);
     return ({
-      userName: user.nickName,
-      userEmail: user.email,
-      userStatus: user.status,
-      userImage: user.avatarImgUri,
+      nickName: user.nickName,
+      email: user.email,
+      secAuthStatus: user.secAuthStatuc,
+      avatarImgUri: user.avatarImgUri,
     });
   }
 

--- a/src/user/repository/user.repository.ts
+++ b/src/user/repository/user.repository.ts
@@ -7,11 +7,11 @@ export class UserRepository extends Repository<User> {
     return this.findOne({ userId: oauthId });
   }
 
-  async createUser(oauthId: number, email: string): Promise<User> {
+  async createUser(oauthId: number, email: string, name: string): Promise<User> {
     const user = new User();
     user.userId = oauthId;
     user.email = email;
-    user.nickName = email;
+    user.nickName = name;
     return this.save(user);
   }
 }

--- a/src/user/user-profile.service.ts
+++ b/src/user/user-profile.service.ts
@@ -41,9 +41,9 @@ export class UserProfileService {
    * @param userData 수정된 유저 정보
    * @return 수정된 유저 정보
    */
-  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<GetUserDto> {
+  async updateUser(userSeq: number, userData: UpdateUserDto): Promise<UpdateUserDto> {
     this.logger.log(`유저 정보 수정 요청: ${userSeq}`);
-    const user:GetUserDto = await this.userProfileRepository.updateUser(userSeq, userData);
+    const user:UpdateUserDto = await this.userProfileRepository.updateUser(userSeq, userData);
     return user;
   }
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,6 @@
 import {
-  BadRequestException,
-  Body,
-  Controller, Delete, ForbiddenException, Get, Logger, Param, Patch, Session, UseGuards, UsePipes, ValidationPipe,
+  BadRequestException, Body, Controller, Delete, ForbiddenException,
+  Get, Logger, Param, Patch, Session, UsePipes, ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiOperation, ApiParam, ApiResponse, ApiTags,
@@ -82,9 +81,8 @@ export class UserController {
   @Patch('/profile')
   async updateUser(
     @Session() session: Record<string, any>,
-    @Body() userData: UpdateUserDto,
+      @Body() userData: UpdateUserDto,
   ): Promise<UpdateUserDto> {
-    console.log(userData);
     const userSeq = session?.passport?.user?.seq;
     this.logger.log(`나의 정보 수정 요청: ${userSeq}`);
 
@@ -106,7 +104,7 @@ export class UserController {
   @ApiResponse({ status: 200, type: GetUserDto, description: '나의 정보 삭제 성공' })
   @Delete('/profile')
   async deleteUser(
-    @Session() session: Record<string, any>,
+  @Session() session: Record<string, any>,
   ) {
     const userSeq = session?.passport?.user?.seq;
     this.logger.log(`유저 정보 삭제 요청: ${userSeq}`);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
-  Controller, Delete, Get, Logger, Param, Patch,
+  Body,
+  Controller, Delete, ForbiddenException, Get, Logger, Param, Patch, Session, UseGuards, UsePipes, ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiOperation, ApiParam, ApiResponse, ApiTags,
@@ -11,6 +12,7 @@ import { UserProfileService } from './user-profile.service';
 
 @ApiTags('유저')
 @Controller('users')
+@UsePipes(new ValidationPipe({ transform: true }))
 export class UserController {
   private readonly logger = new Logger(UserController.name);
 
@@ -30,9 +32,12 @@ export class UserController {
   @ApiParam({
     name: 'user_seq', type: Number, example: 1, description: '유저 시퀀스',
   })
-  @Get('/:user_seq/profile')
+  @Get('/profile/:user_seq')
   async getUser(@Param('user_seq') userSeq: number): Promise<GetUserDto> {
     this.logger.log(`유저 정보 조회 요청: ${userSeq}`);
+    if (userSeq === 0) {
+      throw new ForbiddenException('허가되지 않은 동작입니다.');
+    }
     const check = await this.userProfileService.checkUser(userSeq);
     if (!check) {
       throw new BadRequestException('유저 정보가 존재하지 않습니다.');
@@ -48,10 +53,11 @@ export class UserController {
    */
   @ApiOperation({ summary: '나의 정보 조회', description: '나의 정보를 조회합니다.' })
   @ApiResponse({ status: 200, type: GetUserDto, description: '나의 정보 조회 성공' })
-  @Get('/me/profile')
-  async getMe(): Promise<GetUserDto> {
-    // TODO: session ID를 조회아여 cache에서 userSeq를 가져온다.
-    const userSeq = 1;
+  @Get('/profile')
+  async getMe(
+    @Session() session: Record<string, any>,
+  ): Promise<GetUserDto> {
+    const userSeq = session?.passport?.user?.seq;
     this.logger.log(`나의 정보 조회 요청: ${userSeq}`);
 
     const check = await this.userProfileService.checkUser(userSeq);
@@ -73,10 +79,13 @@ export class UserController {
   @ApiParam({
     name: 'userData', type: UpdateUserDto, example: 1, description: '유저 정보',
   })
-  @Patch('/me/profile')
-  async updateUser(userData: UpdateUserDto): Promise<GetUserDto> {
-    // TODO: session ID를 조회아여 cache에서 userSeq를 가져온다.
-    const userSeq = 1;
+  @Patch('/profile')
+  async updateUser(
+    @Session() session: Record<string, any>,
+    @Body() userData: UpdateUserDto,
+  ): Promise<UpdateUserDto> {
+    console.log(userData);
+    const userSeq = session?.passport?.user?.seq;
     this.logger.log(`나의 정보 수정 요청: ${userSeq}`);
 
     const check = await this.userProfileService.checkUser(userSeq);
@@ -89,16 +98,17 @@ export class UserController {
   }
 
   /**
-   * 유저 정보를 삭제합니다.
+   * 나의 정보를 삭제합니다.
    *
-   * @param userSeq 유저 시퀀스
+   * @param userSeq 나의 시퀀스
    */
-  @ApiOperation({ summary: '유저 정보 삭제', description: '유저 정보를 삭제합니다.' })
-  @ApiResponse({ status: 200, type: GetUserDto, description: '유저 정보 삭제 성공' })
-  @Delete('/me/profile')
-  async deleteUser() {
-    // TODO: session ID를 조회아여 cache에서 userSeq를 가져온다.
-    const userSeq = 1;
+  @ApiOperation({ summary: '나의 정보 삭제', description: '나의 정보를 삭제합니다.' })
+  @ApiResponse({ status: 200, type: GetUserDto, description: '나의 정보 삭제 성공' })
+  @Delete('/profile')
+  async deleteUser(
+    @Session() session: Record<string, any>,
+  ) {
+    const userSeq = session?.passport?.user?.seq;
     this.logger.log(`유저 정보 삭제 요청: ${userSeq}`);
 
     const check = await this.userProfileService.checkUser(userSeq);

--- a/src/user/user.module.e2e-spec.ts
+++ b/src/user/user.module.e2e-spec.ts
@@ -6,6 +6,7 @@ import { UserProfileService } from './user-profile.service';
 import MockUserProfileRepository from './repository/mock/mock.user-profile.repository';
 import { UserProfileRepository } from './repository/user-profile.repository';
 import { UserRepository } from './repository/user.repository';
+import MockUserRepository from './repository/mock/mock.user.repository';
 
 const repositories = [
   {
@@ -14,7 +15,7 @@ const repositories = [
   },
   {
     provide: getRepositoryToken(UserRepository),
-    useClass: MockUserProfileRepository,
+    useClass: MockUserRepository,
   },
 ];
 

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -55,9 +55,10 @@ describe('UserService 테스트', () => {
       // given
       const authId = 123;
       const email = 'test@gmail.com';
+      const name = 'puju';
 
       // when
-      await userService.createByUserId(authId, email);
+      await userService.createByUserId(authId, email, name);
     });
   });
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -37,17 +37,16 @@ export class UserService {
   }
 
   /**
-   * OAuth를 통해 받은 유저 ID와 이메일을 이용해 신규 계정을 만듭니다. 계정이 이미 존재한다면 아무 동작도 하지 않습니다.
-   * NOTE 추후에 확장 가능성 있음
+   * OAuth를 통해 받은 유저 ID와 이메일, 이름을 이용해 신규 계정을 만듭니다. 계정이 이미 존재한다면 아무 동작도 하지 않습니다.
    *
    * @param userId OAuth를 통해 받은 유저 ID
    * @param email 유저 이메일
    * @returns 저장 여부
    */
-  async createByUserId(userId: number, email: string): Promise<void> {
-    this.logger.debug(`UserService.createByUserId: ${userId} ${email}`);
+  async createByUserId(userId: number, email: string, name: string): Promise<void> {
+    this.logger.debug(`UserService.createByUserId: ${userId} ${email} ${name}`);
     if (!await this.userRepository.findByOAuthId(userId)) {
-      await this.userRepository.createUser(userId, email);
+      await this.userRepository.createUser(userId, email, name);
     }
   }
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('User E2E Test', () => {
     // AuthGuard (로그인 확인) Mock 생성
       .overrideGuard(AuthGuard).useValue({
         canActivate: (context: any) => {
-          if (context.switchToHttp().getRequest().session.user) {
+          if (context.switchToHttp().getRequest().session.passport.user.seq) {
             return true;
           }
           throw new HttpException('로그인이 필요합니다.', 401);
@@ -28,8 +28,12 @@ describe('User E2E Test', () => {
       .overrideGuard(FtGuard)
       .useValue({
         canActivate: (context: any) => {
-          // FIXME: 세션의 어느 프로퍼티에 사용자 키 값을 저장하는지 현재는 알 수 없음
-          context.switchToHttp().getRequest().session.user = user;
+          let o = {
+            user: {
+              seq: user,
+            }
+          };
+          context.switchToHttp().getRequest().session.passport = o;
           return true;
         },
       })
@@ -64,25 +68,25 @@ describe('User E2E Test', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  describe.skip('유저 조회', () => {
-    describe('/users/:user_seq/profile', () => {
+  describe('유저 조회', () => {
+    describe('/users/profile/:user_seq', () => {
       test('정상적인 요청', async () => {
         // given
         const userSeq = 1;
 
         // when
         const response = await request(app.getHttpServer())
-          .get(`/users/${userSeq}/profile`);
+          .get(`/users/profile/${userSeq}`);
 
         // then
         expect(response.status).toBe(200);
-        expect(response.body.user_info).toBeDefined();
-        expect(response.body.user_info.user_name).toBeDefined();
-        expect(response.body.user_info.user_email).toBeDefined();
-        expect(response.body.user_info.user_status).toBeDefined();
-        expect(response.body.user_info.user_image).toBeDefined();
-        // expect(response.body.user_info.isFriend).toBeDefined();
-        // expect(response.body.user_info.isBlock).toBeDefined();
+        expect(response.body).toBeDefined();
+        expect(response.body.userName).toBeDefined();
+        expect(response.body.userEmail).toBeDefined();
+        expect(response.body.userStatus).toBeDefined();
+        expect(response.body.userImage).toBeDefined();
+        // expect(response.body.isFriend).toBeDefined();
+        // expect(response.body.isBlock).toBeDefined();
         // NOTE: 다른 테이블과의 조인이 필요한 부분이므로 추후에 검증
       });
 
@@ -92,7 +96,7 @@ describe('User E2E Test', () => {
 
         // when
         const response = await request(app.getHttpServer())
-          .get(`/users/${userSeq}/profile`);
+          .get(`/users/profile/${userSeq}`);
 
         // then
         expect(response.status).toBe(403); // 어드민 계정 조회 금지
@@ -104,14 +108,14 @@ describe('User E2E Test', () => {
 
         // when
         const response = await request(app.getHttpServer())
-          .get(`/users/${userSeq}/profile`);
+          .get(`/users/profile/${userSeq}`);
 
         // then
         expect(response.status).toBe(400);
       });
     });
 
-    describe('/users/me/profile', () => {
+    describe('/users/profile', () => {
       test('정상적인 요청', async () => {
         // given
         // NOTE: 세션 삽입
@@ -119,26 +123,26 @@ describe('User E2E Test', () => {
 
         // when
         const response = await request(app.getHttpServer())
-          .get('/users/me/profile')
+          .get('/users/profile')
           .set('Cookie', userCookie);
 
         // then
         expect(response.status).toBe(200);
-        expect(response.body.user_info).toBeDefined();
-        expect(response.body.user_info.user_name).toBeDefined();
-        expect(response.body.user_info.user_email).toBeDefined();
-        expect(response.body.user_info.user_status).toBeDefined();
-        expect(response.body.user_info.user_image).toBeDefined();
+        expect(response.body).toBeDefined();
+        expect(response.body.userName).toBeDefined();
+        expect(response.body.userEmail).toBeDefined();
+        expect(response.body.userStatus).toBeDefined();
+        expect(response.body.userImage).toBeDefined();
       });
 
       test('비정상적인 요청 - 잘못된 세션', async () => {
         // given
         // NOTE: 세션 삽입
-        const userCookie = cookie;
+        const userCookie = 'string';
 
         // when
         const response = await request(app.getHttpServer())
-          .get('/users/me/profile')
+          .get('/users/profile')
           .set('Cookie', userCookie);
           // TODO: 세션 정보 조회
 
@@ -148,34 +152,42 @@ describe('User E2E Test', () => {
     });
   });
 
-  describe.skip('유저 정보 변경', () => {
-    describe('/user/me/profile', () => {
+  describe('유저 정보 변경', () => {
+    describe('/users/profile', () => {
       test('정상적인 요청', async () => {
         // given
         // NOTE: 세션 삽입
         const userCookie = cookie;
+        const newUserData = {
+          nickName: 'new nickname',
+          email: '123@gmail.com',
+          secAuthStatus: false,
+          avatarImgUri: './img/defaultProfile.jpg',
+        };
 
         // when
         const response = await request(app.getHttpServer())
-          .patch('/users/me/profile')
+          .patch('/users/profile')
+          .send(newUserData)
           .set('Cookie', userCookie);
 
         // then
+        console.log(response.body);
         expect(response.status).toBe(200);
-        expect(response.body.user_info).toBeDefined();
-        expect(response.body.user_info.user_name).toBeDefined();
-        expect(response.body.user_info.user_email).toBeDefined();
-        expect(response.body.user_info.user_status).toBeDefined();
-        expect(response.body.user_info.user_image).toBeDefined();
+        expect(response.body).toBeDefined();
+        expect(response.body.nickName).toEqual(newUserData.nickName);
+        expect(response.body.email).toEqual(newUserData.email);
+        expect(response.body.secAuthStatus).toEqual(newUserData.secAuthStatus);
+        expect(response.body.avatarImgUri).toEqual(newUserData.avatarImgUri);
       });
 
       test('비정상적인 요청', async () => {
         // given
-        const userCookie = cookie; // NOTE: 잘못된 쿠키
+        const userCookie = 'expired';
 
         // when
         const response = await request(app.getHttpServer())
-          .patch('/users/me/profile')
+          .patch('/users/profile')
           .set('Cookie', userCookie);
 
         // then
@@ -185,7 +197,7 @@ describe('User E2E Test', () => {
   });
   // NOTE: 저장 동작은 API를 사용하지 않으므로 생략
 
-  describe.skip('유저 정보 제거', () => {
+  describe('유저 정보 제거', () => {
     test('정상적인 요청', async () => {
       // given
       // NOTE: 세션 삽입
@@ -193,35 +205,21 @@ describe('User E2E Test', () => {
 
       // when
       const response = await request(app.getHttpServer())
-        .delete('/users/me/profile')
+        .delete('/users/profile')
         .set('Cookie', userCookie);
 
       // then
       expect(response.status).toBe(200);
     });
 
-    test('비정상적인 요청 - 어드민 계정 삭제', async () => {
-      // given
-      // NOTE: 세션 삽입
-      const userCookie = cookie;
-
-      // when
-      const response = await request(app.getHttpServer())
-        .delete('/users/me/profile')
-        .set('Cookie', userCookie);
-
-      // then
-      expect(response.status).toBe(403);
-    });
-
     test('비정상적인 요청 - 세션 만료', async () => {
       // given
       // NOTE: 세션 삽입
-      const userCookie = cookie;
+      const userCookie = 'expired';
 
       // when
       const response = await request(app.getHttpServer())
-        .delete('/users/me}/profile')
+        .delete('/users/profile')
         .set('Cookie', userCookie);
 
       // then

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -28,10 +28,10 @@ describe('User E2E Test', () => {
       .overrideGuard(FtGuard)
       .useValue({
         canActivate: (context: any) => {
-          let o = {
+          const o = {
             user: {
               seq: user,
-            }
+            },
           };
           context.switchToHttp().getRequest().session.passport = o;
           return true;
@@ -172,7 +172,6 @@ describe('User E2E Test', () => {
           .set('Cookie', userCookie);
 
         // then
-        console.log(response.body);
         expect(response.status).toBe(200);
         expect(response.body).toBeDefined();
         expect(response.body.nickName).toEqual(newUserData.nickName);


### PR DESCRIPTION
## 수정 및 작업 내용
- #54 작업의 최종 작업
- auth 관련
  - lint 수정
  - callbackURL 수정 (해당 URI는 docker-compose를 통해 구동시키므로 api를 붙여야 합니다.
  - profileFields에 42 인트라 아이디 추가 (해당 아이디를 기본 닉네임으로 설정)
  - validate 수정
## 사유
- #54
