### PR TITLE
Nest.JS 미들웨어 일부 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { CacheModule, Module } from '@nestjs/common';
+import { CacheModule, MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -11,6 +11,7 @@ import { AuthModule } from './auth/auth.module';
 import { GameModule } from './game-log/game.module';
 import { ChatroomsModule } from './chatrooms/chatrooms.module';
 import { CommunityBarModule } from './community-bar/community-bar.module';
+import { SessionMiddleware } from './session-middleware';
 
 @Module({
   imports: [
@@ -31,6 +32,19 @@ import { CommunityBarModule } from './community-bar/community-bar.module';
     CommunityBarModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, SessionMiddleware],
+  exports: [SessionMiddleware],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+
+  constructor(public sessionMiddleware: SessionMiddleware) {}
+
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(
+      this.sessionMiddleware.expressSession,
+      this.sessionMiddleware.passportInit,
+      this.sessionMiddleware.passportSession,
+    ).forRoutes('*');
+  }
+  
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,6 @@
-import { CacheModule, MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import {
+  CacheModule, MiddlewareConsumer, Module, NestModule,
+} from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -36,7 +38,6 @@ import { SessionMiddleware } from './session-middleware';
   exports: [SessionMiddleware],
 })
 export class AppModule implements NestModule {
-
   constructor(public sessionMiddleware: SessionMiddleware) {}
 
   configure(consumer: MiddlewareConsumer) {
@@ -46,5 +47,4 @@ export class AppModule implements NestModule {
       this.sessionMiddleware.passportSession,
     ).forRoutes('*');
   }
-  
 }

--- a/src/game-log/game.gateway.ts
+++ b/src/game-log/game.gateway.ts
@@ -7,7 +7,7 @@ import {
 import { Server } from 'socket.io';
 import GameType from 'src/enums/mastercode/game-type.enum';
 import { SocketGuard } from 'src/guards/socket.guard';
-import { expressSession, passportInit, passportSession } from 'src/session-middleware';
+import { SessionMiddleware } from 'src/session-middleware';
 import {
   PaddleDirective, RenderData, PatchRule, ReadyData, GameData,
 } from './dto/game-data';
@@ -31,6 +31,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   constructor(
     private readonly socketSession: GameSocketSession,
     private readonly gameService: GameService,
+    private readonly sessionMiddleware: SessionMiddleware,
   ) { }
 
   /**
@@ -43,9 +44,9 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       this.socketSession.joinSession(socket, next);
     });
     const wrap = (middleware) => (socket, next) => middleware(socket.request, {}, next);
-    server.use(wrap(expressSession));
-    server.use(wrap(passportInit));
-    server.use(wrap(passportSession));
+    server.use(wrap(this.sessionMiddleware.expressSession));
+    server.use(wrap(this.sessionMiddleware.passportInit));
+    server.use(wrap(this.sessionMiddleware.passportSession));
   }
 
   /**

--- a/src/game-log/game.module.ts
+++ b/src/game-log/game.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import { SessionMiddleware } from 'src/session-middleware';
 import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 import { GameLogRepository, MockGameLogRepository } from './game-log.repository';
@@ -9,7 +10,6 @@ import { SimulationService } from './simulation.service';
 import { GameSocketSession } from './game-socket-session';
 import { GameLogController } from './game-log.controller';
 import { GameLogService } from './game-log.service';
-import { SessionMiddleware } from 'src/session-middleware';
 
 @Module({
   imports: [

--- a/src/game-log/game.module.ts
+++ b/src/game-log/game.module.ts
@@ -9,6 +9,7 @@ import { SimulationService } from './simulation.service';
 import { GameSocketSession } from './game-socket-session';
 import { GameLogController } from './game-log.controller';
 import { GameLogService } from './game-log.service';
+import { SessionMiddleware } from 'src/session-middleware';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { GameLogService } from './game-log.service';
     SimulationService,
     GameSocketSession,
     GameLogService,
+    SessionMiddleware,
   ],
   controllers: [GameLogController],
   exports: [GameGateway],

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,27 +3,12 @@ import * as session from 'express-session';
 import * as passport from 'passport';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import * as sess from 'session-file-store';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: ['log', 'verbose', 'error', 'warn', 'debug'],
   });
-
-  const configService = app.get(ConfigService);
-  const FileStore = sess(session);
-  app.use(
-    session({
-      secret: configService.get('auth.secret'),
-      resave: false,
-      saveUninitialized: true,
-      store: new FileStore(),
-    }),
-  );
-
-  app.use(passport.initialize());
-  app.use(passport.session());
 
   app.enableCors({
     origin: '*',

--- a/src/session-middleware.ts
+++ b/src/session-middleware.ts
@@ -2,27 +2,27 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as session from 'express-session';
 import * as passport from 'passport';
-import * as sess from 'session-file-store';
+import * as SessionFileStore from 'session-file-store';
 
 type Middleware = (req: any, res: any, next: (error?: any) => void) => void;
 
 @Injectable()
 export class SessionMiddleware {
   expressSession: Middleware;
+
   passportInit: Middleware;
+
   passportSession: Middleware;
 
   constructor(private configService: ConfigService) {
-    const _store = new sess(session)();
+    const store = new SessionFileStore(session)();
     this.expressSession = session({
       secret: this.configService.get('auth.secret'),
       resave: false,
       saveUninitialized: true,
-      store: _store,
+      store,
     });
     this.passportInit = passport.initialize();
     this.passportSession = passport.session();
   }
-
 }
-

--- a/src/session-middleware.ts
+++ b/src/session-middleware.ts
@@ -1,11 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as session from 'express-session';
 import * as passport from 'passport';
+import * as sess from 'session-file-store';
 
-export const expressSession = session({
-  secret: process.env.AUTH_SECRET,
-  resave: false,
-  saveUninitialized: true,
-});
+type Middleware = (req: any, res: any, next: (error?: any) => void) => void;
 
-export const passportInit = passport.initialize();
-export const passportSession = passport.session();
+@Injectable()
+export class SessionMiddleware {
+  expressSession: Middleware;
+  passportInit: Middleware;
+  passportSession: Middleware;
+
+  constructor(private configService: ConfigService) {
+    const _store = new sess(session)();
+    this.expressSession = session({
+      secret: this.configService.get('auth.secret'),
+      resave: false,
+      saveUninitialized: true,
+      store: _store,
+    });
+    this.passportInit = passport.initialize();
+    this.passportSession = passport.session();
+  }
+
+}
+

--- a/src/user/repository/mock/mock.user.repository.ts
+++ b/src/user/repository/mock/mock.user.repository.ts
@@ -54,6 +54,7 @@ export default class MockUserRepository {
       createdAt: new Date(),
     };
     this.MockEntity.push(user);
+    return this.MockEntity.at(this.MockEntity.length - 1);
   }
 
   async findByOAuthId(oauthId: number) {


### PR DESCRIPTION
## 수정 및 작업 내용
- @yamkim 님과 @jinbekim 님께서 작업하신 부분을 병합
- 목업DB 메소드 일부 수정
- 미들웨어 설정을 nestjs app 내에서 설정하도록 함
  - 세션 관련 미들웨어는 소켓과 http에서 공통적으로 사용되기 때문에 동일한 인스턴스를 삽입함
  - 소켓에 적용되는 미들웨어는 추후에 세션이 전반적으로 적용될 때 https://docs.nestjs.com/websockets/adapter 를 이용해 전역적으로 적용할 예정 (현재 채팅 관련 기능에서 에러를 유발하기 때문에 전역적으로 적용하긴 이른 것 같습니다.)

## 사유
- #77 #78
