### PR TITLE
Alarm API에 Auth 가드 적용

### DIFF
--- a/src/alarm/alarm.controller.ts
+++ b/src/alarm/alarm.controller.ts
@@ -1,16 +1,18 @@
 import {
-  Controller, Put, Get, Logger, Param, ValidationPipe, Delete, HttpCode, UsePipes,
+  Controller, Put, Get, Logger, Param, ValidationPipe, Delete, HttpCode, UsePipes, UseGuards,
 } from '@nestjs/common';
 import {
   ApiOperation, ApiParam, ApiResponse, ApiTags,
 } from '@nestjs/swagger';
 import { User } from 'src/auth/user.decorator';
+import { CheckLogin } from 'src/guards/check-login.guard';
 import { UserDto } from 'src/user/dto/user.dto';
 import { AlarmService } from './alarm.service';
 import { AlarmResponseDto } from './dto/alarm-response.dto';
 
 @ApiTags('알람')
 @Controller('alarm')
+@UseGuards(CheckLogin)
 @UsePipes(new ValidationPipe({ transform: true }))
 export class AlarmController {
   private logger: Logger = new Logger(AlarmController.name);


### PR DESCRIPTION
## 수정 및 작업 내용
- Alarm API에 Auth 가드 적용

## 사유
- 로그인이 되어있지 않은 경우 존재하지 않는 프로퍼티에 접근해 서버 내부에서 에러가 발생함. 컨트롤러 실행 전 AuthGuard를 적용해 로그인이 되어있지 않을 경우 프로퍼티에 접근하지 않게 함.
