### PR TITLE
fix: 배포 이미지 버그 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:latest
+FROM node:slim
 RUN mkdir backend
 WORKDIR /backend
 COPY . .
 RUN npm install && npm run build
 EXPOSE 3000
-CMD [ "npm", "run", "seed:run" ]
-ENTRYPOINT [ "npm", "run", "start:prod" ]
+CMD ["bash", "start.sh"]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:dev": "nest start --watch",
     "dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "seed:config": "ts-node ./node_modules/typeorm-seeding/dist/cli.js config",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm run seed:run
+npm run start:prod


### PR DESCRIPTION
## 수정 및 작업 내용
- 이미지 용량이 작은 node:slim 이미지로 변경하였습니다.
- 배포시에 빌드하는 dockerfile 내의 스크립트를 변경하였습니다.

## 사유
- CD 서버를 고치기 위해
