### PR TITLE
채팅 리포지토리 적용 #1

### DIFF
--- a/src/chatrooms/chatrooms.gateway.ts
+++ b/src/chatrooms/chatrooms.gateway.ts
@@ -91,7 +91,7 @@ export class ChatroomsGateway implements OnGatewayInit, OnGatewayConnection, OnG
     const userID = userSeq;
     this.logger.debug(`handleDisconnect: ${userID} disconnected`);
     // 본인이 속한 룸에서 나갑니다.
-    await this.chatroomsService.roomLeave(client);
+    await this.chatroomsService.roomLeave(client, userID);
 
     // 클라이언트와 채팅 소켓 연결이 끊어지면 정보를 제거합니다.
     await this.chatroomsService.onlineUserRemove(client);

--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -784,21 +784,6 @@ describe('Chatrooms 테스트', () => {
       clientSocket.close();
     });
 
-    describe('getUserId', () => {
-      test('auth에 주입된 인증 정보 검증 (추후 리팩터링 필요)', (done) => {
-        io.on('connection', async (socket: Socket) => {
-          // when
-          const userId = chatroomsService.getUserId(socket);
-          // then
-          expect(userId).toEqual(123);
-          done();
-        });
-        // given
-        clientSocket.auth = { username: 123 };
-        clientSocket.connect();
-      });
-    });
-
     describe('onlineUserAdd / onlineUserRemove / whoAmI', () => {
       test('사용자 접속 및 접속 해제', (done) => {
         // given

--- a/src/chatrooms/chatrooms.service.ts
+++ b/src/chatrooms/chatrooms.service.ts
@@ -339,18 +339,6 @@ export default class ChatroomsService implements OnModuleInit {
   }
 
   /**
-   * 소켓 연결 단계에서 클라이언트로부터 전송된 사용자 ID를 가져옵니다.
-   * 추후에 사용자 검증을 하는 함수로 리펙터링해야 합니다.
-   *
-   * @param user 클라이언트 소켓
-   * @returns 사용자 ID (없으면 undefined)
-   */
-  getUserId(user: Socket): number | undefined {
-    return Number.isNaN(user.handshake.auth.username)
-      ? undefined : Number(user.handshake.auth.username);
-  }
-
-  /**
    * 접속한 클라이언트 소켓을 소속되어 있는 모든 룸에 추가하고 소속된 룸을 반환합니다.
    *
    * @param user 클라이언트 소켓
@@ -412,9 +400,8 @@ export default class ChatroomsService implements OnModuleInit {
    *
    * @param user 클라이언트 소켓
    */
-  async roomLeave(user: Socket): Promise<void> {
-    const username = this.getUserId(user);
-    const rooms = await this.chatParticipantRepository.findRoomsByUserId(username);
+  async roomLeave(user: Socket, userID: number): Promise<void> {
+    const rooms = await this.chatParticipantRepository.findRoomsByUserId(userID);
     rooms.forEach((room) => {
       user.leave(room.toString()); // 본인이 속한 룸에서 떠나기
     });

--- a/src/chatrooms/repository/chat.repository.ts
+++ b/src/chatrooms/repository/chat.repository.ts
@@ -14,7 +14,17 @@ export default class ChatRepository extends Repository<Chat> {
    * @returns 방 객체 or null
    */
   async findRoomByRoomId(chatSeq: number): Promise<ChatDto | null> {
-    return null;
+    const result = await this.findOne(chatSeq);
+    if (result === null || result === undefined) {
+      return null;
+    }
+    return ({
+      chatSeq: result.chatSeq,
+      chatType: result.chatType,
+      chatName: result.chatName,
+      password: result.password,
+      isDirected: result.isDirected,
+    });
   }
 
   /**
@@ -24,7 +34,21 @@ export default class ChatRepository extends Repository<Chat> {
    * @returns 방 객체 or null
    */
   async findRoomByRoomName(chatName: string): Promise<ChatDto | null> {
-    return null;
+    const result = await this.find({
+      where: {
+        chatName,
+      }
+    });
+    if (result === null || result === undefined) {
+      return null;
+    }
+    return ({
+      chatSeq: result[0].chatSeq,
+      chatType: result[0].chatType,
+      chatName: result[0].chatName,
+      password: result[0].password,
+      isDirected: result[0].isDirected,
+    });
   }
 
   /**
@@ -34,7 +58,13 @@ export default class ChatRepository extends Repository<Chat> {
    * @returns 생성된 방 고유 ID
    */
   async addRoom(room: ChatDto): Promise<number> {
-    return 0;
+    const newChat = new Chat();
+    newChat.chatType = room.chatType;
+    newChat.chatName = room.chatName;
+    newChat.password = room.password;
+    newChat.isDirected = room.isDirected;
+    const result = await this.save(newChat);
+    return result.chatSeq;
   }
 
   /**
@@ -44,7 +74,25 @@ export default class ChatRepository extends Repository<Chat> {
    * @returns 채팅방 객체 배열
    */
   async searchChatroomsByChatType(chatTypes: ChatType[]): Promise<ChatDto[]> {
-    return [];
+    const resultLists = await Promise.all(
+      chatTypes.map((chatType) => this.find({
+        where: {
+          chatType,
+        }
+      })
+    ));
+    let rtn = [];
+    for (let result of resultLists) {
+      const conv = result.map(i => ({
+        chatSeq: i.chatSeq,
+        chatType: i.chatType,
+        chatName: i.chatName,
+        password: i.password,
+        isDirected: i.isDirected,
+      }));
+      rtn = [...rtn, ...conv];
+    }
+    return rtn;
   }
 
   /**
@@ -53,5 +101,6 @@ export default class ChatRepository extends Repository<Chat> {
    * @param chatSeq 방 고유 ID
    */
   async deleteRoom(chatSeq: number): Promise<void> {
+    await this.delete(chatSeq);
   }
 }


### PR DESCRIPTION
## 수정 및 작업 내용
- 채팅에 실DB를 연동함에 따라 기존에 구현이 되어있지 않던 실DB 연동 리포지토리를 일부 구현하였습니다.
- 채팅 관련 DB 리포지토리를 5가지 종류를 사용하는데 우선 3가지만 구현하였으며 이후로 구현을 추가할 예정입니다.

## 사유
- 채팅 실DB 연동 리포지토리 미구현
