### PR TITLE
add: game:watch event

### DIFF
--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -27,6 +27,11 @@ export class GameService {
     private simulator: SimulationService,
   ) {}
 
+  checkPresenceOf(roomId: string): boolean {
+    if (this.games.get(roomId)) return true;
+    return false;
+  }
+
   findCurrentGame(userSeq: number): GameData | undefined {
     const roomId = this.users.get(userSeq);
     return this.games.get(roomId);


### PR DESCRIPTION
## 수정 및 작업 내용
### 서버에서 전달 받는 소켓 이벤트
- `game:watch`
  - 룸 아이디를 넘겨주며 관전을 요청합니다.
- `game:unwatch`
  - 룸 아이디를 넘겨주며 관전을 중지합니다.
### 서버에서 발생하는 소켓 이벤트
- `failure`
  - 해당 요청이 실패했습니다.
- `watcher/enter`
  - 관전자가 방에 입장했습니다.
- `watcher/leave`
  - 관전자가 방을 떠납니다.
