### PR TITLE
fix: 알람 조회기능에 필드 일부 누락 문제 해결

### DIFF
--- a/src/entities/alarm.entity.ts
+++ b/src/entities/alarm.entity.ts
@@ -27,9 +27,11 @@ export default class Alarm {
 
   @ManyToOne(() => User, (user) => user.userSeq)
   @JoinColumn({ name: 'receiverSeq' })
+  @Column()
     receiverSeq: number;
 
   @ManyToOne(() => User, (user) => user.userSeq)
   @JoinColumn({ name: 'senderSeq' })
+  @Column()
     senderSeq: number;
 }


### PR DESCRIPTION
## 수정 및 작업 내용
- 엔티티와 DB 테이블 중 일부가 연동되지 않아 필드가 누락되었었습니다. 그래서 엔티티를 수정하였습니다.

## 사유
- 엔티티 필드 누락으로 인한 알람 조회 API의 HTTP Response 필드 누락