### PR TITLE
#229 alarm issue fix

### DIFF
--- a/src/alarm/alarm.service.ts
+++ b/src/alarm/alarm.service.ts
@@ -125,6 +125,8 @@ export class AlarmService {
         receiverSeq,
         alarmType,
         alarmCode,
+        read: false,
+        delete: false,
       },
     });
     return presence.alarmSeq;

--- a/src/community-bar/friends/friends.controller.ts
+++ b/src/community-bar/friends/friends.controller.ts
@@ -106,7 +106,6 @@ export class FriendsController {
     if (!check) {
       throw new Error('유저 정보가 존재하지 않습니다.');
     }
-    console.log("@@@@@@@@@@@@@@@@@@@@as @@@@@@@@@@@@@@@@@@@@@2");
 
     await this.friendsService.acceptFriend(user.userSeq, target);
     this.eventEitter.emit('friends:update', user.userSeq, target);

--- a/src/community-bar/friends/friends.controller.ts
+++ b/src/community-bar/friends/friends.controller.ts
@@ -106,6 +106,7 @@ export class FriendsController {
     if (!check) {
       throw new Error('유저 정보가 존재하지 않습니다.');
     }
+    console.log("@@@@@@@@@@@@@@@@@@@@as @@@@@@@@@@@@@@@@@@@@@2");
 
     await this.friendsService.acceptFriend(user.userSeq, target);
     this.eventEitter.emit('friends:update', user.userSeq, target);

--- a/src/community-bar/friends/repository/friends.repository.ts
+++ b/src/community-bar/friends/repository/friends.repository.ts
@@ -70,9 +70,15 @@ export class FriendsRepository extends Repository<Friends> {
     if (!friend) {
       throw new BadRequestException('친구가 없습니다.');
     }
-    friend.status = RelationStatus.FRST50;
+    const me = await this.findFriend(target, userSeq, RelationStatus.FRST10);
+    if (!me) {
+      throw new BadRequestException('나에게 친구가 없습니다.');
+    }
+    friend.status = RelationStatus.FRST40;
+    me.status = RelationStatus.FRST40;
 
     await this.save(friend);
+    await this.save(me);
   }
 
   async getRelation(userSeq: number, target: number) : Promise<ProfileRelation | undefined> {

--- a/src/community-bar/friends/repository/mock/mock.friends.repository.ts
+++ b/src/community-bar/friends/repository/mock/mock.friends.repository.ts
@@ -78,7 +78,12 @@ export default class MockFriendsRepository {
     if (!friend) {
       throw new Error('친구가 아닙니다.');
     }
-    friend.status = RelationStatus.FRST50;
+    const me = await this.findFriend(target, userSeq, RelationStatus.FRST10);
+    if (!me) {
+      throw new Error('내 친구가 아닙니다.');
+    }
+    friend.status = RelationStatus.FRST40;
+    me.status = RelationStatus.FRST40;
   }
 
   async getRelation(userSeq: number, target: number) : Promise<ProfileRelation | undefined> {


### PR DESCRIPTION
## 수정 및 작업 내용

- 친구 삭제시 친구 관계에 대한 마스터코드를 FRST50에서 FRST40으로 바꾸었습니다
- 절교하고 다시 친구 요청을 할때 50으로 되어있어서 찾지 못하는 오류가 있었어요
- 또한 친구삭제시 서로간의 친구리스트에서 삭제하기로 했습니다


## 사유
https://github.com/PPiing/backend/issues/229
